### PR TITLE
fix: properly get elpaca package count

### DIFF
--- a/welcome-dashboard.el
+++ b/welcome-dashboard.el
@@ -812,8 +812,8 @@ and parse it json and call (as CALLBACK)."
      (length package-activated-list))
     ((boundp 'straight--profile-cache)
      (hash-table-count straight--profile-cache))
-    ((boundp 'elpaca--queued)
-     (length elpaca--queued))
+    ((boundp 'elpaca-installer-version)
+     (length (elpaca--queued)))
     (t 0)))
 
 


### PR DESCRIPTION
Should fix the package count for elpaca. Tested and worked.

I am not sure this is the best way to fix it, but it is at least one way to fix it.
In my testing I found that `(boundp 'elpaca--queued)` returned nil.

Before:

<img width="435" height="115" alt="image" src="https://github.com/user-attachments/assets/b8b9d546-14ad-4f45-a1a7-9002d710f98c" />


After:

<img width="352" height="101" alt="image" src="https://github.com/user-attachments/assets/0ff5e19c-79cf-49c4-90d4-95cef9bf5e44" />
