### PR TITLE
fix: disable weather info if longitude and latitude is empty

### DIFF
--- a/welcome-dashboard.el
+++ b/welcome-dashboard.el
@@ -554,9 +554,11 @@ And adding an ellipsis."
 
 (defun welcome-dashboard--insert-misc-info ()
   "Insert misc info in the welcome-dashboard buffer."
-  (let ((misc-list (list (welcome-dashboard--weather-info)
-                         (welcome-dashboard--package-info)
-                         (welcome-dashboard--startup-time))))
+  (let ((misc-list (append
+                  (when (and welcome-dashboard-latitude welcome-dashboard-longitude)
+                    (list (welcome-dashboard--weather-info)))
+                  (list (welcome-dashboard--package-info)
+                        (welcome-dashboard--startup-time)))))
 
         (welcome-dashboard--insert-two-columns
          :left-items misc-list


### PR DESCRIPTION
motivation: 
I attempted to set longitude and latitude to nil, but encountered an error.
I believe this should fix it. Works for me at least.